### PR TITLE
If brightness attempt fails, use on/off instead.

### DIFF
--- a/apps/DimmerButtonController/DimmerButtonController.groovy
+++ b/apps/DimmerButtonController/DimmerButtonController.groovy
@@ -585,7 +585,17 @@ def setBri(devices, level) {
 	try {
 		devices.setLevel(level, transitionTime)
 	} catch (e) {
-		log.debug("Unable to set brightness level on ${devices}: ${e}")
+		logDebug("Unable to set brightness level on ${devices}: ${e}\nTrying on/off instead.")
+		try{
+			if(level>0){
+				devices.on()
+			}else{
+				devices.off();
+			}
+
+		}catch(err){
+			log.debug("Unable to turn on/off device ${devices}: ${err}")
+		}
 	}
 }
 
@@ -830,3 +840,5 @@ def logTrace(string) {
 	}
 }
 				   
+
+


### PR DESCRIPTION
I have some TP-link HS100 outlets that I wanted to control with the "rotating scenes" function you created.  But HS-100s don't support dimming.  So I added a on/off fallback option, invoked if dimming fails (greater than 0 in the scene settings is considered "on").

Maybe a try/catch isn’t the best way to do this, and maybe there are other issues with it.  But I find it an improvement, so glad to share with you and your users if it looks useful to you.  Thanks for releasing this code!

