### PR TITLE
Allow long inactivity periods (e.g. one year)+

### DIFF
--- a/apps/DeviceActivityCheck/DeviceActivityCheck1.groovy
+++ b/apps/DeviceActivityCheck/DeviceActivityCheck1.groovy
@@ -274,7 +274,7 @@ List<com.hubitat.app.DeviceWrapper> getInactiveDevices(Boolean sortByName=true) 
       List allDevices = settings["group${groupNum}.devices"] ?: []
       // For "Last Activity at" devices:
       if (settings["group${groupNum}.inactivityMethod"] == "activity" || settings["group${groupNum}.inactivityMethod"] == null) {
-         Integer inactiveMinutes = daysHoursMinutesToMinutes(settings["group${groupNum}.intervalD"],
+         Long inactiveMinutes = daysHoursMinutesToMinutes(settings["group${groupNum}.intervalD"],
             settings["group${groupNum}.intervalH"], settings["group${groupNum}.intervalM"])
          Long cutoffEpochTime = currEpochTime - (inactiveMinutes * 60000)
          inactivityDetectionClosure = { Long cutoffTime, com.hubitat.app.DeviceWrapper dev ->
@@ -316,7 +316,7 @@ void performRefreshes() {
       List allDevices = settings["group${groupNum}.devices"] ?: []
       // For "Last Activity at" devices:
       if (settings["group${groupNum}.inactivityMethod"] == "activity" || settings["group${groupNum}.inactivityMethod"] == null) {
-         Integer inactiveMinutes = daysHoursMinutesToMinutes(settings["group${groupNum}.intervalD"],
+         Long inactiveMinutes = daysHoursMinutesToMinutes(settings["group${groupNum}.intervalD"],
             settings["group${groupNum}.intervalH"], settings["group${groupNum}.intervalM"])
          Long cutoffEpochTime = currEpochTime - (inactiveMinutes * 60000)
          inactivityDetectionClosure = { Long cutoffTime, com.hubitat.app.DeviceWrapper dev ->


### PR DESCRIPTION
The code appears to accidentally use integer here although the method returns a long. A Long is need to store a year in milliseconds. (And why a year? Devices such as a Fireplace or Christmas Lights aren't used regularly.)